### PR TITLE
Added lid holes to snap_box.scad

### DIFF
--- a/snap_box.scad
+++ b/snap_box.scad
@@ -5,8 +5,8 @@
 //                                                                            //
 // Author:  Gavin Smalley                                                     //
 // Link:    https://www.thingiverse.com/thing:3468464                         //
-// Version: 0.1                                                               //
-// Date:    4th March 2019                                                    //
+// Version: 0.2                                                               //
+// Date:    5th March 2019                                                    //
 //                                                                            //
 // Customisable project box                                                   //
 //  (inspired by https://www.youtube.com/watch?v=lBK0UBjVrYM).                //
@@ -14,7 +14,21 @@
 // Latest working version can always be found at the Thingiverse link above.  //
 // Thingiverse customiser can be used with this file.                         //
 //                                                                            //
+// Changelog                                                                  //
+// =========                                                                  //
+//                                                                            //
+// v0.2 (5th March 2019)                                                      //
+//  - Added support for holes in lid                                          //
+//    Up to three rows/columns (choose and blank the other)                   //
+//    Specify array of hole diameters for each row/column. Holes will be      //
+//      equally spaced in the row/column of choosing.                         //
+//                                                                            //
+// v0.1 (4th March 2019)                                                      //
+//  - Initial version                                                         //
+//                                                                            //
 ////////////////////////////////////////////////////////////////////////////////
+
+//Customisable parameters
 
 $fn = 1 * 256;
 // Interal width of box (x-axis)
@@ -38,10 +52,10 @@ snap_depth = 2;
 // Diameter of hole for power-jack (set to 0 to remove hole)
 power_hole_diameter = 9;
 
-// Proto-board width (x-axis) (set to 0 to disable proto-board mounts)
+// Proto-board width (x-axis) (set to 0 to disable proto-board mounts) [This should be the full width, the script automatically positions the center of the mounting pegs 1.75mm in from each edge]
 proto_width = 70; //set to 0 to disable proto-board mounts
 
-// Proto-board depth (y-axis) (set to 0 to disable proto-board mounts)
+// Proto-board depth (y-axis) (set to 0 to disable proto-board mounts) [This should be the full depth, the script automatically positions the center of the mounting pegs 1.75mm in from each edge]
 proto_depth = 30;
 
 // Distance to offset protoboard from box edge (x-axis) (ignored if proto_width or proto_depth are 0)
@@ -56,9 +70,6 @@ proto_height_offset = 5;
 // Thickness of protoboard (ignored if proto_width or proto_depth are 0)
 proto_thickness = 1.6;
 
-// Outside diameter of protoboard support pillars (ignored if proto_width or proto_depth are 0)
-proto_pillar_diameter = 3.5;
-
 // Diameter of holes in protoboard (ignored if proto_width or proto_depth are 0)
 proto_hole_diameter = 2.5;
 
@@ -67,6 +78,30 @@ screw_mount_diameter = 3;
 
 // Distance from inside edge to top of mounting holes
 screw_mount_offset = 5;
+
+//Left row (x-axis) mounting holes holes (add diameter of holes in array eg "[6, 6, 6]" - they will be spaced equally, set to "[]" to disable.)
+left_row_holes = [6, 6,];
+
+//Centre row (x-axis) mounting holes holes (add diameter of holes in array eg "[6, 6, 6]" - they will be spaced equally, set to "[]" to disable.)
+center_row_holes = [];
+
+//Right row (x-axis) mounting holes holes (add diameter of holes in array eg "[6, 6, 6]" - they will be spaced equally, set to "[]" to disable.)
+right_row_holes = [];
+
+//Left column (y-axis) mounting holes holes (add diameter of holes in array eg "[6, 6, 6]" - they will be spaced equally, set to "[]" to disable.)
+left_column_holes = [];
+
+//Centre column (y-axis) mounting holes holes (add diameter of holes in array eg "[6, 6, 6]" - they will be spaced equally, set to "[]" to disable.)
+center_column_holes = [8];
+
+//Right column (y-axis) mounting holes holes (add diameter of holes in array eg "[6, 6, 6]" - they will be spaced equally, set to "[]" to disable.)
+right_column_holes = [];
+
+// Non-customisable parameters
+// (The maths stops them showing up in Thingiverse's customizer app.
+
+$fn = 1 * 256;
+proto_pillar_diameter = 1.0 * 3.5;
 
 box_body();
 proto_mounts_base();
@@ -187,6 +222,8 @@ module box_top() {
           );
         }
       }
+      row_holes();
+      column_holes();
     }
   }
 }
@@ -288,5 +325,121 @@ module screw_mount() {
       h = wall_thickness * 2,
       r = screw_mount_diameter
     );
+  }
+}
+
+module row_holes() {
+  if (len(left_row_holes) > 0) {
+    left_row_num = len(left_row_holes);
+    left_row_spacing = (width + (2 * wall_thickness)) / (left_row_num + 1);
+    left_row_y = (depth + (2 * wall_thickness)) * (3 / 4);
+    translate([
+      -(2 * wall_thickness),
+      left_row_y - (2 * wall_thickness),
+      -(wall_thickness / 2)
+      ]) union () {
+      for (i =[0 : 1: (left_row_num -1)]) {
+        translate ([(left_row_spacing * (i + 1)), 0, 0])
+          cylinder(
+            h = wall_thickness * 2,
+            r = left_row_holes[i] / 2
+        );
+      }
+    }
+  }
+  if (len(center_row_holes) > 0) {
+    center_row_num = len(center_row_holes);
+    center_row_spacing = (width + (2 * wall_thickness)) / (center_row_num + 1);
+    center_row_y = (depth + (2 * wall_thickness)) * (1 / 2);
+    translate([
+      -(2 * wall_thickness),
+      center_row_y - (2 * wall_thickness),
+      -(wall_thickness / 2)
+      ]) union () {
+      for (i =[0 : 1: (center_row_num -1)]) {
+        translate ([(center_row_spacing * (i + 1)), 0, 0])
+          cylinder(
+            h = wall_thickness * 2,
+            r = center_row_holes[i] / 2
+        );
+      }
+    }
+  }
+  if (len(right_row_holes) > 0) {
+    right_row_num = len(right_row_holes);
+    right_row_spacing = (width + (2 * wall_thickness)) / (right_row_num + 1);
+    right_row_y = (depth + (2 * wall_thickness)) * (1 / 4);
+    translate([
+      -(2 * wall_thickness),
+      right_row_y - (2 * wall_thickness),
+      -(wall_thickness / 2)
+      ]) union () {
+      for (i =[0 : 1: (right_row_num -1)]) {
+        translate ([(right_row_spacing * (i + 1)), 0, 0])
+          cylinder(
+            h = wall_thickness * 2,
+            r = right_row_holes[i] / 2
+        );
+      }
+    }
+  }
+}
+
+*column_holes();
+
+module column_holes() {
+  if (len(left_column_holes) > 0) {
+    left_column_num = len(left_column_holes);
+    left_column_spacing = (depth + (2 * wall_thickness)) / (left_column_num + 1);
+    left_column_x = (width + (2 * wall_thickness)) * (1 / 4);
+    translate([
+      left_column_x - (2 * wall_thickness),
+      -(2 * wall_thickness),
+      -(wall_thickness / 2)
+      ]) union () {
+      for (i =[0 : 1: (left_column_num -1)]) {
+        translate ([0, (left_column_spacing * (i + 1)), 0])
+          cylinder(
+            h = wall_thickness * 2,
+            r = left_column_holes[i] / 2
+        );
+      }
+    }
+  }
+  if (len(center_column_holes) > 0) {
+    center_column_num = len(center_column_holes);
+    center_column_spacing = (depth + (2 * wall_thickness)) / (center_column_num + 1);
+    center_column_x = (width + (2 * wall_thickness)) * (1 / 2);
+    translate([
+      center_column_x - (2 * wall_thickness),
+      -(2 * wall_thickness),
+      -(wall_thickness / 2)
+      ]) union () {
+      for (i =[0 : 1: (center_column_num -1)]) {
+        translate ([0, (center_column_spacing * (i + 1)), 0])
+          cylinder(
+            h = wall_thickness * 2,
+            r = center_column_holes[i] / 2
+        );
+      }
+    }
+  }
+  if (len(right_column_holes) > 0) {
+    right_column_num = len(right_column_holes);
+    right_column_spacing = (depth + (2 * wall_thickness)) / (right_column_num + 1);
+    right_column_x = (width + (2 * wall_thickness)) * (3 / 4);
+    translate([
+      right_column_x - (2 * wall_thickness),
+      -(2 * wall_thickness),
+      -(wall_thickness / 2)
+      ]) union () {
+      for (i =[0 : 1: (right_column_num -1)]) {
+        translate ([0, (right_column_spacing * (i + 1)), 0])
+          cylinder(
+            h = wall_thickness * 2,
+            r = right_column_holes[i] / 2
+        );
+      }
+    }
   }
 }


### PR DESCRIPTION
v0.2 (5th March 2019)
Added support for holes in lid. Up to three rows/columns (choose and blank the other). Specify array of hole diameters for each row/column. Holes will be equally spaced in the row/column of choosing.